### PR TITLE
[1.x] Introduce `Str` case conversion

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,3 +11,82 @@ Install the package via Composer:
 ```shell
 composer require flockyn/phpflock
 ```
+
+## Utilities
+
+### String
+
+The `Str` class provides a variety of convenient functions for working with strings.
+These helpers make it easy to transform values into consistent formats, normalize naming conventions, and perform common string manipulations in a clean and expressive way.
+
+#### Available Methods
+
+- [Str::camel](#method-string-camel)
+- [Str::kebab](#method-string-kebab)
+- [Str::pascal](#method-string-pascal)
+- [Str::snake](#method-string-snake)
+
+<a name="method-string-camel"></a>
+##### `Str::camel()`
+
+The `Str::camel` method converts the given string to `camelCase`:
+
+```php
+use Cndrsdrmn\Warp\Str;
+
+Str::camel('first_name');               // firstName
+Str::camel('api-key-value');            // apiKeyValue
+Str::camel('DatabaseConnection');       // databaseConnection
+Str::camel('userIDAndURLPath');         // userIdAndUrlPath
+Str::camel('mixed-case_input Value');   // mixedCaseInputValue
+Str::camel('firstName');                // firstName
+```
+
+<a name="method-string-kebab"></a>
+##### `Str::kebab()`
+
+The `Str::kebab` method converts the given string to `kebab-case`:
+
+```php
+use Cndrsdrmn\Warp\Str;
+
+Str::kebab('first_name');               // first-name
+Str::kebab('api-key-value');            // api-key-value
+Str::kebab('DatabaseConnection');       // database-connection
+Str::kebab('userIDAndURLPath');         // user-id-and-url-path
+Str::kebab('mixed-case_input Value');   // mixed-case-input-value
+Str::kebab('firstName');                // first-name
+```
+
+<a name="method-string-pascal"></a>
+##### `Str::pascal()`
+
+The `Str::pascal` method converts the given string to `PascalCase`:
+
+```php
+use Cndrsdrmn\Warp\Str;
+
+Str::pascal('first_name');               // FirstName
+Str::pascal('api-key-value');            // ApiKeyValue
+Str::pascal('DatabaseConnection');       // DatabaseConnection
+Str::pascal('userIDAndURLPath');         // UserIdAndUrlPath
+Str::pascal('mixed-case_input Value');   // MixedCaseInputValue
+Str::pascal('firstName');                // FirstName
+```
+
+<a name="method-string-snake"></a>
+##### `Str::snake()`
+
+The `Str::snake` method converts the given string to `snake_case`.
+You may also specify a custom separator:
+
+```php
+use Cndrsdrmn\Warp\Str;
+
+Str::snake('first_name', '-');          // first-name
+Str::snake('api-key-value');            // api_key_value
+Str::snake('DatabaseConnection');       // database_connection
+Str::snake('userIDAndURLPath');         // user_id_and_url_path
+Str::snake('mixed-case_input Value');   // mixed_case_input_value
+Str::snake('firstName');                // first_name
+```

--- a/src/Str.php
+++ b/src/Str.php
@@ -14,6 +14,14 @@ final class Str
     private static array $normalizedWords = [];
 
     /**
+     * Convert a string to a camel case.
+     */
+    public static function camel(string $value): string
+    {
+        return lcfirst(self::pascal($value));
+    }
+
+    /**
      * Convert a string to a pascal case.
      */
     public static function pascal(string $value): string

--- a/src/Str.php
+++ b/src/Str.php
@@ -22,6 +22,14 @@ final class Str
     }
 
     /**
+     * Convert a string to a kebab case.
+     */
+    public static function kebab(string $value): string
+    {
+        return self::snake($value, '-');
+    }
+
+    /**
      * Convert a string to a pascal case.
      */
     public static function pascal(string $value): string

--- a/src/Str.php
+++ b/src/Str.php
@@ -22,6 +22,14 @@ final class Str
     }
 
     /**
+     * Convert a string to a snake case.
+     */
+    public static function snake(string $value, string $separator = '_'): string
+    {
+        return implode($separator, self::normalizeToWords($value));
+    }
+
+    /**
      * Normalize a string to words.
      *
      * @return list<string>

--- a/src/Str.php
+++ b/src/Str.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flockyn\PHPFlock;
+
+final class Str
+{
+    /**
+     * Cache for normalized words.
+     *
+     * @var array<string, list<string>>
+     */
+    private static array $normalizedWords = [];
+
+    /**
+     * Convert a string to a pascal case.
+     */
+    public static function pascal(string $value): string
+    {
+        return implode('', array_map('ucfirst', self::normalizeToWords($value)));
+    }
+
+    /**
+     * Normalize a string to words.
+     *
+     * @return list<string>
+     */
+    private static function normalizeToWords(string $value): array
+    {
+        $key = $value;
+
+        if (isset(self::$normalizedWords[$key])) {
+            return self::$normalizedWords[$key];
+        }
+
+        // 1. Insert space before any capital letter preceded by a lowercase letter or digit.
+        $value = preg_replace('/(?<=[a-z0-9])(?=[A-Z])/', ' ', $value);
+
+        // 2. Insert space before the last capital letter in an acronym if it's followed by a lowercase letter.
+        $value = preg_replace('/([A-Z])([A-Z][a-z])/', '$1 $2', (string) $value);
+
+        // 3. Convert all remaining separators to spaces.
+        $value = str_replace(['-', '_'], ' ', (string) $value);
+
+        // 4. Convert to lowercase with UTF-8 encoding.
+        $value = mb_strtolower($value, 'UTF-8');
+
+        // 4. Split by space and remove empty values.
+        /** @var list<string> $normalized */
+        $normalized = array_filter(explode(' ', (string) $value));
+
+        return self::$normalizedWords[$key] = $normalized;
+    }
+}

--- a/tests/StrTest.php
+++ b/tests/StrTest.php
@@ -22,6 +22,17 @@ final class StrTest extends TestCase
     }
 
     #[Test]
+    public function it_kebab_conversion(): void
+    {
+        $this->assertSame('first-name', Str::kebab('first_name'));
+        $this->assertSame('api-key-value', Str::kebab('api-key-value'));
+        $this->assertSame('database-connection', Str::kebab('DatabaseConnection'));
+        $this->assertSame('user-id-and-url-path', Str::kebab('userIDAndURLPath'));
+        $this->assertSame('mixed-case-input-value', Str::kebab('mixed-case_input Value'));
+        $this->assertSame('first-name', Str::kebab('firstName'));
+    }
+
+    #[Test]
     public function it_pascal_conversion(): void
     {
         $this->assertSame('FirstName', Str::pascal('first_name'));

--- a/tests/StrTest.php
+++ b/tests/StrTest.php
@@ -20,4 +20,15 @@ final class StrTest extends TestCase
         $this->assertSame('MixedCaseInputValue', Str::pascal('mixed-case_input Value'));
         $this->assertSame('FirstName', Str::pascal('firstName'));
     }
+
+    #[Test]
+    public function it_snake_conversion(): void
+    {
+        $this->assertSame('first_name', Str::snake('first_name'));
+        $this->assertSame('api_key_value', Str::snake('api-key-value'));
+        $this->assertSame('database_connection', Str::snake('DatabaseConnection'));
+        $this->assertSame('user_id_and_url_path', Str::snake('userIDAndURLPath'));
+        $this->assertSame('mixed_case_input_value', Str::snake('mixed-case_input Value'));
+        $this->assertSame('first_name', Str::snake('firstName'));
+    }
 }

--- a/tests/StrTest.php
+++ b/tests/StrTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use Flockyn\PHPFlock\Str;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class StrTest extends TestCase
+{
+    #[Test]
+    public function it_pascal_conversion(): void
+    {
+        $this->assertSame('FirstName', Str::pascal('first_name'));
+        $this->assertSame('ApiKeyValue', Str::pascal('api-key-value'));
+        $this->assertSame('DatabaseConnection', Str::pascal('DatabaseConnection'));
+        $this->assertSame('UserIdAndUrlPath', Str::pascal('userIDAndURLPath'));
+        $this->assertSame('MixedCaseInputValue', Str::pascal('mixed-case_input Value'));
+        $this->assertSame('FirstName', Str::pascal('firstName'));
+    }
+}

--- a/tests/StrTest.php
+++ b/tests/StrTest.php
@@ -11,6 +11,17 @@ use PHPUnit\Framework\TestCase;
 final class StrTest extends TestCase
 {
     #[Test]
+    public function it_camel_conversion(): void
+    {
+        $this->assertSame('firstName', Str::camel('first_name'));
+        $this->assertSame('apiKeyValue', Str::camel('api-key-value'));
+        $this->assertSame('databaseConnection', Str::camel('DatabaseConnection'));
+        $this->assertSame('userIdAndUrlPath', Str::camel('userIDAndURLPath'));
+        $this->assertSame('mixedCaseInputValue', Str::camel('mixed-case_input Value'));
+        $this->assertSame('firstName', Str::camel('firstName'));
+    }
+
+    #[Test]
     public function it_pascal_conversion(): void
     {
         $this->assertSame('FirstName', Str::pascal('first_name'));


### PR DESCRIPTION
This Pull Request introduces a foundational new utility class, `Str`, dedicated to robust string manipulation and case conversion. This addition is crucial for providing reliable, high-quality key casing functionality necessary for handling complex data structures (like those from external APIs or configuration files) where keys might use mixed casing or acronyms.

Provides four highly reliable methods (`camel`, `pascal`, `snake`, `kebab`) that can convert any input case to the target case, utilizing advanced logic to correctly break up acronyms and mixed separators.