### PR TITLE
[1.x] Introduce `Arr` utilities

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,310 @@ composer require flockyn/phpflock
 
 ## Utilities
 
+### Array
+
+The `Arr` class provides a robust and flexible collection of array manipulation methods.
+These utilities are designed to simplify common data transformation tasks, such as key casing and advanced mapping, in a clear and non-destructive manner.
+
+#### Available Methods
+
+- [Arr::keyCase](#method-array-key-case)
+- [Arr::mapWithKeys](#method-array-map-with-keys)
+- [Arr::toCamelKeys](#method-array-to-camel-keys)
+- [Arr::toKebabKeys](#method-array-to-kebab-keys)
+- [Arr::toPascalKeys](#method-array-to-pascal-keys)
+- [Arr::toSnakeKeys](#method-array-to-snake-keys)
+
+<a name="method-array-key-case"></a>
+##### `Arr::keyCase()`
+
+The `Arr::keyCase` method changes the case of array keys to a specified style.
+It supports recursive traversal with depth control and also accepts custom casing callbacks.
+
+###### Enum Values
+
+When using the `ArrKeyCase` enum, the following cases are available:
+
+| Enum                 | Example Conversion |
+|----------------------|--------------------|
+| `ArrKeyCase::Camel`  | `camelCase`        |
+| `ArrKeyCase::Kebab`  | `kebab-case`       |
+| `ArrKeyCase::Pascal` | `PascalCase`       |
+| `ArrKeyCase::Snake`  | `snake_case`       |
+
+```php
+use Cndrsdrmn\Warp\Arr;
+use Cndrsdrmn\Warp\Enums\ArrKeyCase;
+
+$array = [
+    'first_name' => 'John',
+    'last_name' => 'Doe',
+    'address' => [
+        'street_name' => 'Main Street',
+        'postal_code' => '12345',
+    ],
+];
+
+$camel = Arr::keyCase($array, ArrKeyCase::Camel);
+
+/*
+    [
+        'firstName' => 'John',
+        'lastName' => 'Doe',
+        'address' => [
+            'streetName' => 'Main Street',
+            'postalCode' => '12345',
+        ],
+    ]
+*/
+```
+
+You may also use a custom callback to transform the key:
+
+```php
+$upper = Arr::keyCase($array, fn ($key) => strtoupper($key));
+
+/*
+    [
+        'FIRST_NAME' => 'John',
+        'LAST_NAME' => 'Doe',
+        'ADDRESS' => [
+            'STREET_NAME' => 'Main Street',
+            'POSTAL_CODE' => '12345',
+        ],
+    ]
+*/
+```
+
+You may limit the transformation depth by passing the number of levels to transform:
+
+```php
+$shallow = Arr::keyCase($array, ArrKeyCase::Camel, 1);
+
+/*
+    [
+        'firstName' => 'John',
+        'lastName' => 'Doe',
+        'address' => [
+            'street_name' => 'Main Street',
+            'postal_code' => '12345',
+        ],
+    ]
+*/
+```
+<a name="method-array-map-with-keys"></a>
+##### `Arr::mapWithKeys()`
+
+The `Arr::mapWithKeys` method maps an array into a new array by running each value through a callback.
+The callback must return an associative array of key-value pairs:
+
+```php
+use Cndrsdrmn\Warp\Arr;
+
+$array = [
+    ['id' => 1, 'name' => 'John'],
+    ['id' => 2, 'name' => 'Jane'],
+];
+
+$result = Arr::mapWithKeys($array, fn ($item) => [
+    $item['id'] => $item['name'],
+]);
+
+// [1 => 'John', 2 => 'Jane']
+```
+
+<a name="method-array-to-camel-keys"></a>
+##### `Arr::toCamelKeys()`
+
+The `Arr::toCamelKeys` method converts all array keys to `camelCase`:
+
+```php
+use Cndrsdrmn\Warp\Arr;
+
+$array = [
+    'first_name' => 'John',
+    'last_name' => 'Doe',
+    'address' => [
+        'street_name' => 'Main Street',
+        'postal_code' => '12345',
+    ],
+];
+
+$camel = Arr::toCamelKeys($array);
+
+/*
+    [
+        'firstName' => 'John',
+        'lastName' => 'Doe',
+        'address' => [
+            'streetName' => 'Main Street',
+            'postalCode' => '12345',
+        ],
+    ]
+*/
+```
+
+Depth control is supported:
+
+```php
+$shallow = Arr::toCamelKeys($array, 1);
+
+/*
+    [
+        'firstName' => 'John',
+        'lastName' => 'Doe',
+        'address' => [
+            'street_name' => 'Main Street',
+            'postal_code' => '12345',
+        ],
+    ]
+*/
+```
+
+<a name="method-array-to-kebab-keys"></a>
+##### `Arr::toKebabKeys()`
+
+The `Arr::toKebabKeys` method converts all array keys to `kebab-case`:
+
+```php
+use Cndrsdrmn\Warp\Arr;
+
+$array = [
+    'first_name' => 'John',
+    'last_name' => 'Doe',
+    'address' => [
+        'street_name' => 'Main Street',
+        'postal_code' => '12345',
+    ],
+];
+
+$kebab = Arr::toKebabKeys($array);
+
+/*
+    [
+        'first-name' => 'John',
+        'last-name' => 'Doe',
+        'address' => [
+            'street-name' => 'Main Street',
+            'postal-code' => '12345',
+        ],
+    ]
+*/
+```
+
+Depth control is supported:
+
+```php
+$shallow = Arr::toKebabKeys($array, 1);
+
+/*
+    [
+        'first-name' => 'John',
+        'last-name' => 'Doe',
+        'address' => [
+            'street_name' => 'Main Street',
+            'postal_code' => '12345',
+        ],
+    ]
+*/
+```
+
+<a name="method-array-to-pascal-keys"></a>
+##### `Arr::toPascalKeys()`
+
+The `Arr::toPascalKeys` method converts all array keys to `PascalCase`:
+
+```php
+use Cndrsdrmn\Warp\Arr;
+
+$array = [
+    'first_name' => 'John',
+    'last_name' => 'Doe',
+    'address' => [
+        'street_name' => 'Main Street',
+        'postal_code' => '12345',
+    ],
+];
+
+$pascal = Arr::toPascalKeys($array);
+
+/*
+    [
+        'FirstName' => 'John',
+        'LastName' => 'Doe',
+        'Address' => [
+            'StreetName' => 'Main Street',
+            'PostalCode' => '12345',
+        ],
+    ]
+*/
+```
+
+Depth control is supported:
+
+```php
+$shallow = Arr::toPascalKeys($array, 1);
+
+/*
+    [
+        'FirstName' => 'John',
+        'LastName' => 'Doe',
+        'Address' => [
+            'street_name' => 'Main Street',
+            'postal_code' => '12345',
+        ],
+    ]
+*/
+```
+
+<a name="method-array-to-snake-keys"></a>
+##### `Arr::toSnakeKeys()`
+
+The `Arr::toSnakeKeys` method converts all array keys to `snake_case`:
+
+```php
+use Cndrsdrmn\Warp\Arr;
+
+$array = [
+    'first Name' => 'John',
+    'lastName' => 'Doe',
+    'address' => [
+        'StreetName' => 'Main Street',
+        'PostalCode' => '12345',
+    ],
+];
+
+$snake = Arr::toSnakeKeys($array);
+
+/*
+    [
+        'first_name' => 'John',
+        'last_name' => 'Doe',
+        'address' => [
+            'street_name' => 'Main Street',
+            'postal_code' => '12345',
+        ],
+    ]
+*/
+```
+
+Depth control is supported:
+
+```php
+$shallow = Arr::toSnakeKeys($array, 1);
+
+/*
+    [
+        'first_name' => 'John',
+        'last_name' => 'Doe',
+        'address' => [
+            'StreetName' => 'Main Street',
+            'PostalCode' => '12345',
+        ],
+    ]
+*/
+```
+
 ### String
 
 The `Str` class provides a variety of convenient functions for working with strings.

--- a/src/Arr.php
+++ b/src/Arr.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flockyn\PHPFlock;
+
+final class Arr
+{
+    /**
+     * Map the given array using the given callback.
+     *
+     * @template TKey of array-key
+     * @template TValue
+     * @template TMapWithKeysKey of array-key
+     * @template TMapWithKeysValue
+     *
+     * @param  array<TKey, TValue>  $array
+     * @param  callable(TValue, TKey): array<TMapWithKeysKey, TMapWithKeysValue>  $callback
+     * @return array<TMapWithKeysKey, TMapWithKeysValue>
+     */
+    public static function mapWithKeys(array $array, callable $callback): array
+    {
+        $result = [];
+
+        foreach ($array as $key => $value) {
+            $assoc = $callback($value, $key);
+
+            foreach ($assoc as $mapKey => $mapValue) {
+                $result[$mapKey] = $mapValue;
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/Arr.php
+++ b/src/Arr.php
@@ -91,4 +91,15 @@ final class Arr
     {
         return self::keyCase($array, ArrKeyCase::Pascal, $depth);
     }
+
+    /**
+     * Change the case of array keys to the snake case.
+     *
+     * @param  array<array-key, mixed>  $array
+     * @return array<array-key, mixed>
+     */
+    public static function toSnakeKeys(array $array, float|int $depth = INF): array
+    {
+        return self::keyCase($array, ArrKeyCase::Snake, $depth);
+    }
 }

--- a/src/Arr.php
+++ b/src/Arr.php
@@ -4,8 +4,34 @@ declare(strict_types=1);
 
 namespace Flockyn\PHPFlock;
 
+use Flockyn\PHPFlock\Enums\ArrKeyCase;
+
 final class Arr
 {
+    /**
+     * Change the case of array keys to the specified case.
+     *
+     * @param  array<array-key, mixed>  $array
+     * @param  ArrKeyCase|callable(string): string  $case
+     * @return array<array-key, mixed>
+     */
+    public static function keyCase(array $array, ArrKeyCase|callable $case, float|int $depth = INF): array
+    {
+        return self::mapWithKeys($array, static function ($value, int|string $key) use ($case, $depth): array {
+            if (is_array($value) && $depth > 1) {
+                $value = self::keyCase($value, $case, $depth - 1);
+            }
+
+            $newKey = $key;
+
+            if (is_string($newKey)) {
+                $newKey = is_callable($case) ? $case($key) : $case->convert($key);
+            }
+
+            return [$newKey => $value];
+        });
+    }
+
     /**
      * Map the given array using the given callback.
      *

--- a/src/Arr.php
+++ b/src/Arr.php
@@ -58,4 +58,15 @@ final class Arr
 
         return $result;
     }
+
+    /**
+     * Change the case of array keys to the camel case.
+     *
+     * @param  array<array-key, mixed>  $array
+     * @return array<array-key, mixed>
+     */
+    public static function toCamelKeys(array $array, float|int $depth = INF): array
+    {
+        return self::keyCase($array, ArrKeyCase::Camel, $depth);
+    }
 }

--- a/src/Arr.php
+++ b/src/Arr.php
@@ -69,4 +69,15 @@ final class Arr
     {
         return self::keyCase($array, ArrKeyCase::Camel, $depth);
     }
+
+    /**
+     * Change the case of array keys to the kebab case.
+     *
+     * @param  array<array-key, mixed>  $array
+     * @return array<array-key, mixed>
+     */
+    public static function toKebabKeys(array $array, float|int $depth = INF): array
+    {
+        return self::keyCase($array, ArrKeyCase::Kebab, $depth);
+    }
 }

--- a/src/Arr.php
+++ b/src/Arr.php
@@ -80,4 +80,15 @@ final class Arr
     {
         return self::keyCase($array, ArrKeyCase::Kebab, $depth);
     }
+
+    /**
+     * Change the case of array keys to the pascal case.
+     *
+     * @param  array<array-key, mixed>  $array
+     * @return array<array-key, mixed>
+     */
+    public static function toPascalKeys(array $array, float|int $depth = INF): array
+    {
+        return self::keyCase($array, ArrKeyCase::Pascal, $depth);
+    }
 }

--- a/src/Enums/ArrKeyCase.php
+++ b/src/Enums/ArrKeyCase.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flockyn\PHPFlock\Enums;
+
+use Flockyn\PHPFlock\Str;
+
+enum ArrKeyCase
+{
+    case Camel;
+    case Kebab;
+    case Pascal;
+    case Snake;
+
+    /**
+     * Apply the case transformation to the given string.
+     */
+    public function convert(string $value): string
+    {
+        return match ($this) {
+            self::Camel => Str::camel($value),
+            self::Kebab => Str::kebab($value),
+            self::Pascal => Str::pascal($value),
+            self::Snake => Str::snake($value),
+        };
+    }
+}

--- a/tests/ArrTest.php
+++ b/tests/ArrTest.php
@@ -143,6 +143,14 @@ final class ArrTest extends TestCase
         $this->assertSame($expected, $result);
     }
 
+    #[Test]
+    public function it_to_camel_keys_conversion(): void
+    {
+        $data = Arr::toCamelKeys($this->dataKeyCaseConversion());
+
+        $this->assertSame(self::keyCaseCamelExpectedConversion(), $data);
+    }
+
     private static function keyCaseCamelExpectedConversion(?array $nested = null): array
     {
         $nested ??= [

--- a/tests/ArrTest.php
+++ b/tests/ArrTest.php
@@ -167,6 +167,14 @@ final class ArrTest extends TestCase
         $this->assertSame(self::keyCasePascalExpectedConversion(), $data);
     }
 
+    #[Test]
+    public function it_to_snake_keys_conversion(): void
+    {
+        $data = Arr::toSnakeKeys($this->dataKeyCaseConversion());
+
+        $this->assertSame(self::keyCaseSnakeExpectedConversion(), $data);
+    }
+
     private static function keyCaseCamelExpectedConversion(?array $nested = null): array
     {
         $nested ??= [

--- a/tests/ArrTest.php
+++ b/tests/ArrTest.php
@@ -151,6 +151,14 @@ final class ArrTest extends TestCase
         $this->assertSame(self::keyCaseCamelExpectedConversion(), $data);
     }
 
+    #[Test]
+    public function it_to_kebab_keys_conversion(): void
+    {
+        $data = Arr::toKebabKeys($this->dataKeyCaseConversion());
+
+        $this->assertSame(self::keyCaseKebabExpectedConversion(), $data);
+    }
+
     private static function keyCaseCamelExpectedConversion(?array $nested = null): array
     {
         $nested ??= [

--- a/tests/ArrTest.php
+++ b/tests/ArrTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use Flockyn\PHPFlock\Arr;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class ArrTest extends TestCase
+{
+    public static function dataProviderMapWithKeys(): array
+    {
+        return [
+            'basic mapping' => [
+                'data' => [
+                    100 => ['id' => 1, 'name' => 'Alice', 'role' => 'Admin'],
+                    200 => ['id' => 2, 'name' => 'Bob', 'role' => 'Guest'],
+                    300 => ['id' => 3, 'name' => 'Charlie', 'role' => 'Admin'],
+                ],
+                'callback' => static fn (array $user): array => [$user['name'] => $user['id']],
+                'expected' => [
+                    'Alice' => 1,
+                    'Bob' => 2,
+                    'Charlie' => 3,
+                ],
+            ],
+            'filtering items' => [
+                'data' => [
+                    ['status' => 'active', 'data' => 'A'],
+                    ['status' => 'pending', 'data' => 'B'],
+                    ['status' => 'active', 'data' => 'C'],
+                ],
+                'callback' => static fn (array $item, int $key): array => $item['status'] === 'active' ? [$item['data'] => $key] : [],
+                'expected' => [
+                    'A' => 0,
+                    'C' => 2,
+                ],
+            ],
+            'overwriting keys' => [
+                'data' => [
+                    'primary' => 1,
+                    'secondary' => 2,
+                    'final' => 3,
+                ],
+                'callback' => static fn (int $value): array => ['merged_value' => $value],
+                'expected' => ['merged_value' => 3],
+            ],
+        ];
+    }
+
+    #[Test, DataProvider('dataProviderMapWithKeys')]
+    public function it_map_with_keys(array $data, callable $callback, array $expected): void
+    {
+        $result = Arr::mapWithKeys($data, $callback);
+
+        $this->assertSame($expected, $result);
+    }
+}

--- a/tests/ArrTest.php
+++ b/tests/ArrTest.php
@@ -5,12 +5,88 @@ declare(strict_types=1);
 namespace Tests;
 
 use Flockyn\PHPFlock\Arr;
+use Flockyn\PHPFlock\Enums\ArrKeyCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 final class ArrTest extends TestCase
 {
+    public static function dataProviderKeyCase(): array
+    {
+        static $nested = [
+            'is_active' => true,
+            'login-attempts' => 3,
+            'preferences' => ['LanguageCode' => 'en', 'theme_color' => 'dark', 'font-size' => 'medium'],
+        ];
+
+        $keyCaseCallable = [
+            'callable_first_name' => 'John',
+            'callable_email-address' => 'john@example.com',
+            'callable_userid' => 100,
+            'callable_urlpath-foravatar' => 'https://example.com/avatar.jpg',
+            'callable_logs' => [0 => 'Log entry 1', 1 => 'Log entry 2'],
+            'callable_account_settings' => [
+                'callable_is_active' => true,
+                'callable_login-attempts' => 3,
+                'callable_preferences' => ['callable_languagecode' => 'en', 'callable_theme_color' => 'dark', 'callable_font-size' => 'medium'],
+            ],
+        ];
+
+        return [
+            'camel case depth inf' => [
+                'expected' => self::keyCaseCamelExpectedConversion(),
+                'case' => ArrKeyCase::Camel,
+                'depth' => INF,
+            ],
+            'camel case depth 1' => [
+                'expected' => self::keyCaseCamelExpectedConversion($nested),
+                'case' => ArrKeyCase::Camel,
+                'depth' => 1,
+            ],
+            'kebab case depth inf' => [
+                'expected' => self::keyCaseKebabExpectedConversion(),
+                'case' => ArrKeyCase::Kebab,
+                'depth' => INF,
+            ],
+            'kebab case depth 1' => [
+                'expected' => self::keyCaseKebabExpectedConversion($nested),
+                'case' => ArrKeyCase::Kebab,
+                'depth' => 1,
+            ],
+            'pascal case depth inf' => [
+                'expected' => self::keyCasePascalExpectedConversion(),
+                'case' => ArrKeyCase::Pascal,
+                'depth' => INF,
+            ],
+            'pascal case depth 1' => [
+                'expected' => self::keyCasePascalExpectedConversion($nested),
+                'case' => ArrKeyCase::Pascal,
+                'depth' => 1,
+            ],
+            'snake case depth inf' => [
+                'expected' => self::keyCaseSnakeExpectedConversion(),
+                'case' => ArrKeyCase::Snake,
+                'depth' => INF,
+            ],
+            'snake case depth 1' => [
+                'expected' => self::keyCaseSnakeExpectedConversion($nested),
+                'case' => ArrKeyCase::Snake,
+                'depth' => 1,
+            ],
+            'callable case depth inf' => [
+                'expected' => $keyCaseCallable,
+                'case' => fn (string $key): string => 'callable_'.mb_strtolower($key),
+                'depth' => INF,
+            ],
+            'callable case depth 1' => [
+                'expected' => self::keyCaseSnakeExpectedConversion($nested),
+                'case' => fn (string $key): string => ArrKeyCase::Snake->convert($key),
+                'depth' => 1,
+            ],
+        ];
+    }
+
     public static function dataProviderMapWithKeys(): array
     {
         return [
@@ -51,11 +127,107 @@ final class ArrTest extends TestCase
         ];
     }
 
+    #[Test, DataProvider('dataProviderKeyCase')]
+    public function it_key_case_conversion(array $expected, ArrKeyCase|callable $case, float|int $depth): void
+    {
+        $data = Arr::keyCase($this->dataKeyCaseConversion(), $case, $depth);
+
+        $this->assertSame($expected, $data);
+    }
+
     #[Test, DataProvider('dataProviderMapWithKeys')]
     public function it_map_with_keys(array $data, callable $callback, array $expected): void
     {
         $result = Arr::mapWithKeys($data, $callback);
 
         $this->assertSame($expected, $result);
+    }
+
+    private static function keyCaseCamelExpectedConversion(?array $nested = null): array
+    {
+        $nested ??= [
+            'isActive' => true,
+            'loginAttempts' => 3,
+            'preferences' => ['languageCode' => 'en', 'themeColor' => 'dark', 'fontSize' => 'medium'],
+        ];
+
+        return [
+            'firstName' => 'John',
+            'emailAddress' => 'john@example.com',
+            'userId' => 100,
+            'urlPathForAvatar' => 'https://example.com/avatar.jpg',
+            'logs' => [0 => 'Log entry 1', 1 => 'Log entry 2'],
+            'accountSettings' => $nested,
+        ];
+    }
+
+    private static function keyCaseKebabExpectedConversion(?array $nested = null): array
+    {
+        $nested ??= [
+            'is-active' => true,
+            'login-attempts' => 3,
+            'preferences' => ['language-code' => 'en', 'theme-color' => 'dark', 'font-size' => 'medium'],
+        ];
+
+        return [
+            'first-name' => 'John',
+            'email-address' => 'john@example.com',
+            'user-id' => 100,
+            'url-path-for-avatar' => 'https://example.com/avatar.jpg',
+            'logs' => [0 => 'Log entry 1', 1 => 'Log entry 2'],
+            'account-settings' => $nested,
+        ];
+    }
+
+    private static function keyCasePascalExpectedConversion(?array $nested = null): array
+    {
+        $nested ??= [
+            'IsActive' => true,
+            'LoginAttempts' => 3,
+            'Preferences' => ['LanguageCode' => 'en', 'ThemeColor' => 'dark', 'FontSize' => 'medium'],
+        ];
+
+        return [
+            'FirstName' => 'John',
+            'EmailAddress' => 'john@example.com',
+            'UserId' => 100,
+            'UrlPathForAvatar' => 'https://example.com/avatar.jpg',
+            'Logs' => [0 => 'Log entry 1', 1 => 'Log entry 2'],
+            'AccountSettings' => $nested,
+        ];
+    }
+
+    private static function keyCaseSnakeExpectedConversion(?array $nested = null): array
+    {
+        $nested ??= [
+            'is_active' => true,
+            'login_attempts' => 3,
+            'preferences' => ['language_code' => 'en', 'theme_color' => 'dark', 'font_size' => 'medium'],
+        ];
+
+        return [
+            'first_name' => 'John',
+            'email_address' => 'john@example.com',
+            'user_id' => 100,
+            'url_path_for_avatar' => 'https://example.com/avatar.jpg',
+            'logs' => [0 => 'Log entry 1', 1 => 'Log entry 2'],
+            'account_settings' => $nested,
+        ];
+    }
+
+    private function dataKeyCaseConversion(): array
+    {
+        return [
+            'first_name' => 'John',
+            'email-address' => 'john@example.com',
+            'UserID' => 100,
+            'URLPath-forAvatar' => 'https://example.com/avatar.jpg',
+            'logs' => [0 => 'Log entry 1', 1 => 'Log entry 2'],
+            'account_settings' => [
+                'is_active' => true,
+                'login-attempts' => 3,
+                'preferences' => ['LanguageCode' => 'en', 'theme_color' => 'dark', 'font-size' => 'medium'],
+            ],
+        ];
     }
 }

--- a/tests/ArrTest.php
+++ b/tests/ArrTest.php
@@ -159,6 +159,14 @@ final class ArrTest extends TestCase
         $this->assertSame(self::keyCaseKebabExpectedConversion(), $data);
     }
 
+    #[Test]
+    public function it_to_pascal_keys_conversion(): void
+    {
+        $data = Arr::toPascalKeys($this->dataKeyCaseConversion());
+
+        $this->assertSame(self::keyCasePascalExpectedConversion(), $data);
+    }
+
     private static function keyCaseCamelExpectedConversion(?array $nested = null): array
     {
         $nested ??= [


### PR DESCRIPTION
This pull request introduces new `Arr` utilities that include functions for transforming array keys to various string cases (`camel`, `snake`, `kebab`, `pascal`) using a new `ArrKeyCase` enum and a foundational `Arr::keyCase` method. This simplifies handling data interchange formats.