### PR TITLE
[1.x] Introduce `Arr::isAssoc` to check if an array is associative

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,12 +21,25 @@ These utilities are designed to simplify common data transformation tasks, such 
 
 #### Available Methods
 
+- [Arr::isAssoc](#method-array-is-assoc)
 - [Arr::keyCase](#method-array-key-case)
 - [Arr::mapWithKeys](#method-array-map-with-keys)
 - [Arr::toCamelKeys](#method-array-to-camel-keys)
 - [Arr::toKebabKeys](#method-array-to-kebab-keys)
 - [Arr::toPascalKeys](#method-array-to-pascal-keys)
 - [Arr::toSnakeKeys](#method-array-to-snake-keys)
+
+<a name="method-array-is-assoc"></a>
+##### `Arr::isAssoc()`
+
+The `Arr::isAssoc` method determines if the given array is associative.
+
+```php
+use Flockyn\PHPFlock\Arr;
+
+Arr::isAssoc(['a' => 1, 'b' => 2, 'c' => 3]) // true
+Arr::isAssoc([1, 2, 3]) // false
+```
 
 <a name="method-array-key-case"></a>
 ##### `Arr::keyCase()`

--- a/src/Arr.php
+++ b/src/Arr.php
@@ -9,6 +9,20 @@ use Flockyn\PHPFlock\Enums\ArrKeyCase;
 final class Arr
 {
     /**
+     * Determine whether the given array is associative.
+     *
+     * @param  array<array-key, mixed>  $array
+     */
+    public static function isAssoc(array $array): bool
+    {
+        if (Val::blank($array)) {
+            return false;
+        }
+
+        return ! array_is_list($array);
+    }
+
+    /**
      * Change the case of array keys to the specified case.
      *
      * @param  array<array-key, mixed>  $array

--- a/tests/ArrTest.php
+++ b/tests/ArrTest.php
@@ -127,6 +127,13 @@ final class ArrTest extends TestCase
         ];
     }
 
+    #[Test]
+    public function it_is_assoc(): void
+    {
+        $this->assertTrue(Arr::isAssoc(['a' => 1, 'b' => 2, 'c' => 3]));
+        $this->assertFalse(Arr::isAssoc([1, 2, 3]));
+    }
+
     #[Test, DataProvider('dataProviderKeyCase')]
     public function it_key_case_conversion(array $expected, ArrKeyCase|callable $case, float|int $depth): void
     {


### PR DESCRIPTION
This pull request introduces a new array helper for determining whether an array is associative.